### PR TITLE
refactor: replace set functions with setters

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,31 +28,43 @@ const { ccclass, property } = _decorator;
 @ccclass('DemoSpatialAudioSource')
 export class DemoSpatialAudioSource extends Component 
 {
+    @property(AudioClip)
+    public audioClip: AudioClip = null;
+
+    @property(SpatialAudioSource)
+    public spatialAudioSource: SpatialAudioSource = null;
+
+    @property(AudioChannel)
+    public audioChannel: AudioChannel = null;
+
     public demoSpatialAudioSource(): void
     {
+        // Set audio clip that should play next (Not affect on currently playing clip)
+        this.spatialAudioSource.clip = this.audioClip;
+        
         // Enable looping
-        this.spatialAudioSource.setLoop(true);
+        this.spatialAudioSource.loop = true;
         
         // Set the volume in Range [0, 1]
-        this.spatialAudioSource.setVolume(1);
+        this.spatialAudioSource.volume = 1;
 
         // Set the playback rate in Range [0, 4]
-        this.spatialAudioSource.setPlaybackRate(2);
+        this.spatialAudioSource.playbackRate = 2;
 
         // Set the panning model 
-        this.spatialAudioSource.setPanningModel(PanningModel.HRTF);
+        this.spatialAudioSource.panningModel = PanningModel.HRTF;
 
         // Set the distance model which describes how the volume of sound decreases with distance
-        this.spatialAudioSource.setDistanceModel(DistanceModel.INVERSE);
+        this.spatialAudioSource.distanceModel = DistanceModel.INVERSE;
 
         // Set the volume rolloff factor; a higher value means a steeper decrease in volume with distance
-        this.spatialAudioSource.setVolumeRolloffFactor(100);
+        this.spatialAudioSource.volumeRolloffFactor = 100;
 
         // Set the minimum distance for sound attenuation; sounds will be at full volume within this distance
-        this.spatialAudioSource.setMinDistance(10);
+        this.spatialAudioSource.minDistance = 10;
 
         // Set the maximum distance for sound attenuation; sounds will be inaudible beyond this distance
-        this.spatialAudioSource.setMaxDistance(1000);
+        this.spatialAudioSource.maxDistance = 1000;
 
         // Assign the audio channel to the spatial audio source
         this.spatialAudioSource.setAudioChannelByTag("Demo Audio Channel");
@@ -73,3 +85,8 @@ export class DemoSpatialAudioSource extends Component
     }
 }
 ```
+
+## References
+
+- [[Share] 3D Audio Solution for Cocos Creator 3.x](https://forum.cocosengine.org/t/share-3d-audio-solution-for-cocos-creator-3-x/61068) - A forum post, discussing the 3D audio solution adapted for Cocos Creator 3.X.
+- [Web Audio API - MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API) - A detailed guide on the Web Audio API, covering its capabilities and implementation.

--- a/spatial-audio/assets/nodes/null-audio-buffer-source-node.ts
+++ b/spatial-audio/assets/nodes/null-audio-buffer-source-node.ts
@@ -1,0 +1,47 @@
+import NullAudioParam from './null-audio-param';
+
+export default class NullAudioBufferSourceNode implements AudioBufferSourceNode 
+{
+    public buffer: AudioBuffer | null = null;
+
+    public loop: boolean = false;
+
+    public loopEnd: number = 0;
+    public loopStart: number = 0;
+
+    public detune: AudioParam = new NullAudioParam();
+    public playbackRate: AudioParam = new NullAudioParam();
+
+    readonly channelCount: number = 1;
+    readonly channelCountMode: ChannelCountMode = "max";
+    readonly channelInterpretation: ChannelInterpretation = "speakers";
+
+    readonly context: BaseAudioContext;
+    readonly numberOfInputs: number = 0;
+    readonly numberOfOutputs: number = 1;
+    
+    public onended: ((this: AudioScheduledSourceNode, ev: Event) => any) | null = null;
+
+    constructor(context: BaseAudioContext) 
+    {
+        this.context = context;
+		this.playbackRate.value = 1;
+    }
+
+    public addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, _options?: boolean | AddEventListenerOptions): void { }
+    public removeEventListener(type: string, listener: EventListenerOrEventListenerObject | null, _options?: boolean | EventListenerOptions): void { }
+    public dispatchEvent(_event: Event): boolean 
+    {
+        return true;
+    }
+
+    public start(_when?: number, _offset?: number, _duration?: number): void { }
+    public stop(_when?: number): void { }
+
+    public connect(destinationNode: AudioNode | AudioParam, _output?: number, _input?: number): AudioNode 
+    {
+        return destinationNode as AudioNode;
+    }
+
+    public disconnect(): void { }
+}

--- a/spatial-audio/assets/nodes/null-audio-param.ts
+++ b/spatial-audio/assets/nodes/null-audio-param.ts
@@ -1,0 +1,48 @@
+export default class NullAudioParam implements AudioParam 
+{
+    public value: number = 0;
+    public automationRate: AutomationRate = "a-rate";
+    public defaultValue: number = 0;
+    public maxValue: number = 0;
+    public minValue: number = 0;
+
+    public cancelAndHoldAtTime(_cancelTime: number): AudioParam 
+	{
+        return this;
+    }
+
+    public cancelScheduledValues(_startTime: number): AudioParam 
+	{
+        return this;
+    }
+
+    public exponentialRampToValueAtTime(_value: number, _endTime: number): AudioParam 
+	{
+        return this;
+    }
+
+    public linearRampToValueAtTime(_value: number, _endTime: number): AudioParam 
+	{
+        return this;
+    }
+
+    public setTargetAtTime
+    (
+        _target: number,
+        _startTime: number,
+        _timeConstant: number
+    ): AudioParam 
+	{
+        return this;
+    }
+
+    public setValueAtTime(_value: number, _startTime: number): AudioParam 
+	{
+        return this;
+    }
+
+    public setValueCurveAtTime(_values: Iterable<number>, _startTime: number, _duration: number): AudioParam 
+	{
+        return this;
+    }
+}

--- a/spatial-audio/assets/nodes/null-gain-node.ts
+++ b/spatial-audio/assets/nodes/null-gain-node.ts
@@ -1,0 +1,34 @@
+import NullAudioParam from './null-audio-param';
+
+export default class NullGainNode implements GainNode 
+{
+	public readonly gain: AudioParam = new NullAudioParam();
+
+	public readonly channelCount: number = 2;
+	public readonly channelCountMode: ChannelCountMode = "max";
+	public readonly channelInterpretation: ChannelInterpretation = "speakers";
+
+	public readonly context: BaseAudioContext;
+	public readonly numberOfInputs: number = 1;
+	public readonly numberOfOutputs: number = 1;
+
+	constructor(context: BaseAudioContext) 
+	{
+		this.context = context;
+		this.gain.value = 1;
+	}
+
+	public connect(destinationNode: AudioNode | AudioParam, _output?: number, _input?: number): AudioNode 
+	{
+		return destinationNode as AudioNode;
+	}
+
+	public disconnect(): void { }
+
+	public addEventListener(_type: string, _listener: EventListenerOrEventListenerObject | null, _options?: boolean | AddEventListenerOptions): void { }
+	public removeEventListener(_type: string, _listener: EventListenerOrEventListenerObject | null, _options?: boolean | EventListenerOptions): void { }
+	public dispatchEvent(_event: Event): boolean 
+	{
+		return true;
+	}
+}

--- a/spatial-audio/assets/nodes/null-panner-node.ts
+++ b/spatial-audio/assets/nodes/null-panner-node.ts
@@ -1,0 +1,55 @@
+import NullAudioParam from './null-audio-param';
+
+export default class NullPannerNode implements PannerNode
+{
+	public readonly panningModel: PanningModelType = "equalpower";
+	public readonly distanceModel: DistanceModelType = "inverse";
+
+	public readonly refDistance: number = 1;
+	public readonly maxDistance: number = 10000;
+	public readonly rolloffFactor: number = 1;
+
+	public readonly coneInnerAngle: number = 360;
+	public readonly coneOuterAngle: number = 360;
+	public readonly coneOuterGain: number = 0;
+
+	public readonly positionX: AudioParam = new NullAudioParam();
+	public readonly positionY: AudioParam = new NullAudioParam();
+	public readonly positionZ: AudioParam = new NullAudioParam();
+
+	public readonly orientationX: AudioParam = new NullAudioParam();
+	public readonly orientationY: AudioParam = new NullAudioParam();
+	public readonly orientationZ: AudioParam = new NullAudioParam();
+
+	public readonly channelCount: number = 2;
+	public readonly channelCountMode: ChannelCountMode = "clamped-max";
+	public readonly channelInterpretation: ChannelInterpretation = "speakers";
+
+	public readonly context: BaseAudioContext;
+	public readonly numberOfInputs: number = 1;
+	public readonly numberOfOutputs: number = 2;
+
+	constructor(context: BaseAudioContext)
+	{
+		this.context = context;
+	}
+
+	public setPosition(_x: number, _y: number, _z: number): void {}
+	public setOrientation(_x: number, _y: number, _z: number): void {}
+
+	// AudioNode methods
+	public connect(destinationNode: AudioNode | AudioParam, _output?: number, _input?: number): AudioNode 
+	{
+		return destinationNode as AudioNode;
+	}
+
+	public disconnect(): void {}
+
+	public addEventListener(_type: string, _listener: EventListenerOrEventListenerObject | null, _options?: boolean | AddEventListenerOptions): void {}
+	public removeEventListener(_type: string, _listener: EventListenerOrEventListenerObject | null, _options?: boolean | EventListenerOptions): void {}
+
+	public dispatchEvent(_event: Event): boolean 
+	{
+		return true;
+	}
+}


### PR DESCRIPTION
SpatialAudioSource
- Replaced all functions starting with 'set*' with setter methods.
- Implemented the Null Object Pattern to avoid null checks in setters.

README
- Updated the demo script and added a references section.